### PR TITLE
JCN-104-iac-api-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- When fails building throw an exit code.
+
 ## [1.0.1] - 2019-07-16
 ### Added
 - `index` fix for npx excecution

--- a/lib/iac-api-builder.js
+++ b/lib/iac-api-builder.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
@@ -106,8 +108,10 @@ class IacApiBuilder {
 
 		logger('Building [IaC] API Gateway', 'START');
 
-		if(!await this.exists(this.constructor.schemasJSON))
-			return logger(`API-Schemas file does not exist: '${this.constructor.schemasJSON}'.`, 'ERROR', true);
+		if(!await this.exists(this.constructor.schemasJSON)) {
+			logger(`API-Schemas file does not exist: '${this.constructor.schemasJSON}'.`, 'ERROR', true);
+			return process.exit(-1);
+		}
 
 		logger(`API-Schemas file found in '${this.constructor.schemasJSON}'.`);
 
@@ -115,7 +119,8 @@ class IacApiBuilder {
 		try {
 			schema = await this.getSchemasJSON();
 		} catch(error) {
-			return logger(`File '${this.constructor.schemasJSON}' but Invalid JSON. Error: ${error.message}.`, 'ERROR', true);
+			logger(`File '${this.constructor.schemasJSON}' but Invalid JSON. Error: ${error.message}.`, 'ERROR', true);
+			return process.exit(-1);
 		}
 
 		logger('Copying Files.');
@@ -123,15 +128,18 @@ class IacApiBuilder {
 		try {
 			await this.initBuiltFile();
 		} catch(error) {
-			return logger(`Can't copy Files. Error: ${error.message}.`, 'ERROR', true);
+			logger(`Can't copy Files. Error: ${error.message}.`, 'ERROR', true);
+			return process.exit(-1);
 		}
 
 		logger(`Copied Files to '${this.constructor.buildFilePath}'.`);
 
 		const paths = schema.paths ? Object.entries(schema.paths) : [];
 
-		if(!paths.length)
-			return logger('No paths to build', 'ERROR', true);
+		if(!paths.length) {
+			logger('No paths to build', 'ERROR', true);
+			return process.exit(-1);
+		}
 
 		logger('Paths Found. Init Build.');
 
@@ -140,7 +148,8 @@ class IacApiBuilder {
 				await this.buildPath(apiPath, apiPathData);
 
 		} catch(error) {
-			return logger(`Can't build Files. Error: ${error.message}`, 'ERROR', true);
+			logger(`Can't build Files. Error: ${error.message}`, 'ERROR', true);
+			return process.exit(-1);
 		}
 
 		return logger('[IaC] API Gateway template built', 'SUCCESS');

--- a/tests/iac-api-builder-test.js
+++ b/tests/iac-api-builder-test.js
@@ -108,7 +108,7 @@ describe('IacApiBuilder', () => {
 		before(() => {
 			sandbox.stub(console, 'log');
 			sandbox.stub(console, 'error');
-
+			sandbox.stub(process, 'exit');
 			fsMock = sandbox.mock(fs);
 		});
 
@@ -143,6 +143,7 @@ describe('IacApiBuilder', () => {
 			beforeEach(() => {
 				sandbox.stub(console, 'log');
 				sandbox.stub(console, 'error');
+				sandbox.stub(process, 'exit');
 
 				fsMock = sandbox.mock(fs);
 				builderMock = sandbox.mock(builder);
@@ -223,6 +224,7 @@ describe('IacApiBuilder', () => {
 			beforeEach(() => {
 				sandbox.stub(console, 'log');
 				sandbox.stub(console, 'error');
+				sandbox.stub(process, 'exit');
 
 				fsMock = sandbox.mock(fs);
 				builderMock = sandbox.mock(builder);

--- a/tests/iac-api-builder-test.js
+++ b/tests/iac-api-builder-test.js
@@ -102,13 +102,14 @@ describe('IacApiBuilder', () => {
 
 	const builder = new IacApiBuilder();
 	let fsMock;
+	let exit;
 
 	context('when API-Schemas file doesn\'t exist', () => {
 
 		before(() => {
 			sandbox.stub(console, 'log');
 			sandbox.stub(console, 'error');
-			sandbox.stub(process, 'exit');
+			exit = sandbox.stub(process, 'exit');
 			fsMock = sandbox.mock(fs);
 		});
 
@@ -131,6 +132,9 @@ describe('IacApiBuilder', () => {
 
 			await assert.doesNotReject(builder.build());
 
+			sandbox.assert.calledOnce(exit);
+			sandbox.assert.calledWith(exit, -1);
+
 			fsMock.verify();
 		});
 	});
@@ -143,7 +147,7 @@ describe('IacApiBuilder', () => {
 			beforeEach(() => {
 				sandbox.stub(console, 'log');
 				sandbox.stub(console, 'error');
-				sandbox.stub(process, 'exit');
+				exit = sandbox.stub(process, 'exit');
 
 				fsMock = sandbox.mock(fs);
 				builderMock = sandbox.mock(builder);
@@ -183,6 +187,9 @@ describe('IacApiBuilder', () => {
 
 				await builder.build();
 
+				sandbox.assert.calledOnce(exit);
+				sandbox.assert.calledWith(exit, -1);
+
 				fsMock.verify();
 				builderMock.verify();
 			});
@@ -215,6 +222,9 @@ describe('IacApiBuilder', () => {
 
 				await builder.build();
 
+				sandbox.assert.calledOnce(exit);
+				sandbox.assert.calledWith(exit, -1);
+
 				fsMock.verify();
 
 			});
@@ -224,7 +234,7 @@ describe('IacApiBuilder', () => {
 			beforeEach(() => {
 				sandbox.stub(console, 'log');
 				sandbox.stub(console, 'error');
-				sandbox.stub(process, 'exit');
+				exit = sandbox.stub(process, 'exit');
 
 				fsMock = sandbox.mock(fs);
 				builderMock = sandbox.mock(builder);
@@ -255,6 +265,9 @@ describe('IacApiBuilder', () => {
 				builderMock.expects('buildPath').never();
 
 				await builder.build();
+
+				sandbox.assert.calledOnce(exit);
+				sandbox.assert.calledWith(exit, -1);
 
 				fsMock.verify();
 				builderMock.verify();
@@ -289,6 +302,9 @@ describe('IacApiBuilder', () => {
 				builderMock.expects('buildPath').never();
 
 				await builder.build();
+
+				sandbox.assert.calledOnce(exit);
+				sandbox.assert.calledWith(exit, -1);
 
 				fsMock.verify();
 				builderMock.verify();


### PR DESCRIPTION
**PAQUETE IAC-API-BUILDER**
JCN-104 Paquete npm iac-api-builder

**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-104

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se solicita agregar código de error de salida al fallar el building

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agrego el `process.exit(-1)` cuando falla el building.
Se corrigieron los unit test.